### PR TITLE
Reset RPM only on timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ table can be found in [avr/src/pearson.c](avr/src/pearson.c).
 
 ## Changelog
 
+ * 2018-11-11 Reset RPM only on timeout preventing sporadic 0 RPM responses.
  * 2016-01-31 BOD (brown-out detection) enabled.
  * 2015-03-24 Pulse stretching is implemented. Client code is finished.
  * 2014-07-27 Client code is mostly working.

--- a/avr/src/rpm.c
+++ b/avr/src/rpm.c
@@ -70,28 +70,30 @@ void rpm_update(uint8_t fan, uint16_t rpm) {
 
 void rpm_measure_fan(uint8_t fan) {
 
-    // Resets RPM to 0.
-
-    rpm_update(fan, 0);
-
-    uint16_t start;
-
     // Wait for first rising.
 
     rpm_wait_rising(fan);
 
     if (measure_timeout) {
 
+        // Resets RPM to 0.
+
+        rpm_update(fan, 0);
+
         return;
     }
 
-    start = TCNT1;
+    uint16_t start = TCNT1;
 
-    // Wait for second risin.
+    // Wait for second rising.
 
     rpm_wait_rising(fan);
 
     if (measure_timeout) {
+
+        // Resets RPM to 0.
+
+        rpm_update(fan, 0);
 
         return;
     }


### PR DESCRIPTION
This prevents sporadic 0 RPM responses.