### PR TITLE
Implement missing get-pwm command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ table can be found in [avr/src/pearson.c](avr/src/pearson.c).
 
 ## Changelog
 
+ * 2018-11-11 Implement missing get-pwm command.
  * 2016-01-31 BOD (brown-out detection) enabled.
  * 2015-03-24 Pulse stretching is implemented. Client code is finished.
  * 2014-07-27 Client code is mostly working.

--- a/avr/src/protocol.c
+++ b/avr/src/protocol.c
@@ -299,6 +299,34 @@ void protocol_command_run() {
 
         break;
 
+        case COMMAND_GET_PWM_0:
+
+            protocol_send_buffer_put(RESPONSE_OK);
+            protocol_send_buffer_put(fan_get_pwm(0));
+
+        break;
+
+        case COMMAND_GET_PWM_1:
+
+            protocol_send_buffer_put(RESPONSE_OK);
+            protocol_send_buffer_put(fan_get_pwm(1));
+
+        break;
+
+        case COMMAND_GET_PWM_2:
+
+            protocol_send_buffer_put(RESPONSE_OK);
+            protocol_send_buffer_put(fan_get_pwm(2));
+
+        break;
+
+        case COMMAND_GET_PWM_3:
+
+            protocol_send_buffer_put(RESPONSE_OK);
+            protocol_send_buffer_put(fan_get_pwm(3));
+
+        break;
+
         case COMMAND_ENABLE_0:
 
             fan_enable(0);


### PR DESCRIPTION
This command is defined but the implementation is missing.