### PR TITLE
Do not reset PWM on disable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ table can be found in [avr/src/pearson.c](avr/src/pearson.c).
 
 ## Changelog
 
+ * 2018-11-11 Do not reset PWM on disable.
  * 2016-01-31 BOD (brown-out detection) enabled.
  * 2015-03-24 Pulse stretching is implemented. Client code is finished.
  * 2014-07-27 Client code is mostly working.

--- a/avr/src/protocol.c
+++ b/avr/src/protocol.c
@@ -329,7 +329,6 @@ void protocol_command_run() {
 
         case COMMAND_DISABLE_0:
 
-            fan_set_pwm(0, 0);
             fan_disable(0);
             protocol_send_buffer_put(RESPONSE_OK);
 
@@ -337,7 +336,6 @@ void protocol_command_run() {
 
         case COMMAND_DISABLE_1:
 
-            fan_set_pwm(1, 0);
             fan_disable(1);
             protocol_send_buffer_put(RESPONSE_OK);
 
@@ -345,7 +343,6 @@ void protocol_command_run() {
 
         case COMMAND_DISABLE_2:
 
-            fan_set_pwm(2, 0);
             fan_disable(2);
             protocol_send_buffer_put(RESPONSE_OK);
 
@@ -353,7 +350,6 @@ void protocol_command_run() {
 
         case COMMAND_DISABLE_3:
 
-            fan_set_pwm(3, 0);
             fan_disable(3);
             protocol_send_buffer_put(RESPONSE_OK);
 


### PR DESCRIPTION
Removes surprising and undocumented behavior.